### PR TITLE
Change configuration so that it can be retrieved from different sources

### DIFF
--- a/src/BittrexApi/Bittrex.csproj
+++ b/src/BittrexApi/Bittrex.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="package.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/BittrexApi/Bittrex.csproj
+++ b/src/BittrexApi/Bittrex.csproj
@@ -34,6 +34,7 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -46,6 +47,7 @@
     <Compile Include="Api\AccountApi.cs" />
     <Compile Include="Api\MarketApi.cs" />
     <Compile Include="Api\PublicApi.cs" />
+    <Compile Include="Helpers\ConfigRetrieverBase.cs" />
     <Compile Include="Helpers\HttpUtilities.cs" />
     <Compile Include="Helpers\JsonResultArrayWrapper.cs" />
     <Compile Include="Helpers\JsonResultWrapper.cs" />

--- a/src/BittrexApi/Helpers/ConfigRetrieverBase.cs
+++ b/src/BittrexApi/Helpers/ConfigRetrieverBase.cs
@@ -29,7 +29,7 @@ namespace Bittrex.Helpers
 
     public class ConfigRetrieverRegistry : ConfigRetrieverBase
     {
-        public RegistryView View = RegistryView.Registry64;
+        public RegistryView View = RegistryView.Registry32;
         public override bool HasConfig
         {
             get

--- a/src/BittrexApi/Helpers/ConfigRetrieverBase.cs
+++ b/src/BittrexApi/Helpers/ConfigRetrieverBase.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.Win32;
+using System.Configuration;
+
+namespace Bittrex.Helpers
+{
+    public abstract class ConfigRetrieverBase
+    {
+        public abstract bool HasConfig { get; }
+        protected abstract Tuple<string, string> GetApiKeyAndSecret();
+
+        public Tuple<string, string> GetApiAndSecret()
+        {
+            var apiAndSecret = GetApiKeyAndSecret();
+            if (apiAndSecret == null)
+            {
+                throw new Exception("ApiKey/ApiSecret not specified");
+            }
+            return apiAndSecret;
+        }
+
+        public const string ApiRegistryPathLocalMachine = @"Software\Bittrex";
+        public const string ApiRegistryPathCurrentUser = @"Software\Bittrex";
+        public const string ApiRegistryPathApiKey = @"ApiKey";
+        public const string ApiRegistryPathApiSecret = @"ApiSecret";
+        public const string ApiConfigurationApiKey = "BittrexApiKey";
+        public const string ApiConfigurationApiSecret = "BittrexApiSecret";
+    }
+
+    public class ConfigRetrieverRegistry : ConfigRetrieverBase
+    {
+        public RegistryView View = RegistryView.Registry64;
+        public override bool HasConfig
+        {
+            get
+            {
+                using (var bittrexRegKey = 
+                        RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, View).OpenSubKey(ApiRegistryPathLocalMachine) 
+                        ?? RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, View).OpenSubKey(ApiRegistryPathCurrentUser))
+                {
+                    if (bittrexRegKey == null)
+                    {
+                        return false;
+                    }
+                    return !string.IsNullOrWhiteSpace(bittrexRegKey.GetValue(ApiRegistryPathApiKey) as string)
+                        && !string.IsNullOrWhiteSpace(bittrexRegKey.GetValue(ApiRegistryPathApiSecret) as string);
+                }
+            }
+        }
+        
+        protected override Tuple<string, string> GetApiKeyAndSecret()
+        {
+            string apiKey = null;
+            string apiSecret = null;
+
+            using (var bittrexRegKey = Registry.LocalMachine.OpenSubKey(ApiRegistryPathLocalMachine))
+            {
+                if (bittrexRegKey != null)
+                {
+                    apiKey = bittrexRegKey.GetValue(ApiRegistryPathApiKey) as string;
+                    apiSecret = bittrexRegKey.GetValue(ApiRegistryPathApiSecret) as string;
+                }
+            }
+
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
+            {
+                using (var bittrexRegKey = Registry.CurrentUser.OpenSubKey(ApiRegistryPathCurrentUser))
+                {
+                    if (bittrexRegKey != null)
+                    {
+                        apiKey = bittrexRegKey.GetValue(ApiRegistryPathApiKey) as string;
+                        apiSecret = bittrexRegKey.GetValue(ApiRegistryPathApiSecret) as string;
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
+            {
+                return null;
+            }
+
+            return new Tuple<string, string>(apiKey, apiSecret);
+        }
+    }
+    
+    public class ConfigRetrieverConfigFile : ConfigRetrieverBase
+    {
+        public override bool HasConfig
+        {
+            get
+            {
+                return !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings[ApiConfigurationApiKey]) 
+                        && !string.IsNullOrWhiteSpace(ConfigurationManager.AppSettings[ApiConfigurationApiSecret]);
+            }
+        }
+
+        protected override Tuple<string, string> GetApiKeyAndSecret()
+        {
+            if (!HasConfig)
+            {
+                return null;
+            }
+            return new Tuple<string, string>(ConfigurationManager.AppSettings[ApiConfigurationApiKey], ConfigurationManager.AppSettings[ApiConfigurationApiSecret]);
+        }
+    }
+}

--- a/src/BittrexApi/Helpers/HttpUtilities.cs
+++ b/src/BittrexApi/Helpers/HttpUtilities.cs
@@ -4,50 +4,17 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Win32;
 
 namespace Bittrex.Helpers
 {
     public static class HttpUtilities
     {
-        private static Tuple<string, string> GetApiKeyAndSecret()
-        {
-            string apiKey = null;
-            string apiSecret = null;
-
-            using (var bittrexRegKey = Registry.LocalMachine.OpenSubKey(@"Software\Bittrex"))
-            {
-                if (bittrexRegKey != null)
-                {
-                    apiKey = bittrexRegKey.GetValue("ApiKey") as string;
-                    apiSecret = bittrexRegKey.GetValue("ApiSecret") as string;
-                }
-            }
-
-            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
-            {
-                using (var bittrexRegKey = Registry.CurrentUser.OpenSubKey(@"Software\Bittrex"))
-                {
-                    if (bittrexRegKey != null)
-                    {
-                        apiKey = bittrexRegKey.GetValue("ApiKey") as string;
-                        apiSecret = bittrexRegKey.GetValue("ApiSecret") as string;
-                    }
-                }
-            }
-
-            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(apiSecret))
-            {
-                throw new Exception("ApiKey/ApiSecret not specified");
-            }
-
-            return new Tuple<string, string>(apiKey, apiSecret);
-        }
+        public static ConfigRetrieverBase ConfigRetriever { get; set; } = new ConfigRetrieverRegistry();
 
         public static async Task<string> GetHttpResponseAsync(string url, bool sendApiSign = false)
         {
             string apiSignString = string.Empty;
-            var apiKeyAndSecret = GetApiKeyAndSecret();
+            var apiKeyAndSecret = ConfigRetriever.GetApiAndSecret();
             var apiKey = apiKeyAndSecret.Item1;
             var apiSecret = apiKeyAndSecret.Item2;
 

--- a/src/BittrexApi/Models/BalanceModel.cs
+++ b/src/BittrexApi/Models/BalanceModel.cs
@@ -5,12 +5,11 @@ namespace Bittrex.Models
     public class BalanceModel
     {
         public string Currency { get; set; }
-        public double Balance { get; set; }
-        public double Available { get; set; }
-        public double Pending { get; set; }
+        public double? Balance { get; set; }
+        public double? Available { get; set; }
+        public double? Pending { get; set; }
         public string CryptoAddress { get; set; }
         public bool Requested { get; set; }
         public Guid? Uuid { get; set; }
-
     }
 }

--- a/src/BittrexApi/Properties/AssemblyInfo.cs
+++ b/src/BittrexApi/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("BittrexApi")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Library for connecting to Bittrex API")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("raghupallavi")]
 [assembly: AssemblyProduct("BittrexApi")]
 [assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]

--- a/src/BittrexApi/package.nuspec
+++ b/src/BittrexApi/package.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <!--*-->
+    <id>$id$</id>
+    <!--*-->
+    <version>1.0.0.0</version>
+    <title>
+    </title>
+    <!--*-->
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <projectUrl>https://github.com/raghupallavi/Bittrex-CSharp-Api</projectUrl>
+    <!--
+    <licenseUrl></licenseUrl>
+    <iconUrl></iconUrl>
+-->
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <!--*-->
+    <description>$description$</description>
+    <!--*-->
+    <releaseNotes>first&amp;#x0020;use</releaseNotes>
+    <copyright>$copyright$</copyright>
+    <tags>
+    </tags>
+    <dependencies>
+   <group targetFramework="net452">
+      <dependency id="Newtonsoft.Json" version="10.0.3" />
+   </group>
+</dependencies>
+  </metadata>
+</package>

--- a/src/UnitTests/ApiConfigTests.cs
+++ b/src/UnitTests/ApiConfigTests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bittrex.Helpers;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class ApiConfigTests
+    {
+        [TestMethod]
+        public void ConfigRetrieverIsRegistryByDefault()
+        {
+            Assert.IsInstanceOfType(HttpUtilities.ConfigRetriever, typeof(ConfigRetrieverRegistry));
+            HttpUtilities.ConfigRetriever = new ConfigRetrieverConfigFile();
+            Assert.IsInstanceOfType(HttpUtilities.ConfigRetriever, typeof(ConfigRetrieverConfigFile));
+        }
+
+        [TestMethod]
+        public void AppConfigConfigurationIsDefined()
+        {
+            Assert.IsTrue(new ConfigRetrieverConfigFile().HasConfig);
+        }
+
+        /// <summary>
+        ///  Runs against the registry, if not set up, will fail.
+        /// </summary>
+        [TestMethod]
+        [Ignore()]
+        public void AppConfigRegistryIsDefined()
+        {
+            Assert.IsTrue(new ConfigRetrieverRegistry().HasConfig);
+        }        
+    }
+}

--- a/src/UnitTests/App.config
+++ b/src/UnitTests/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="BittrexApiKey" value="ApiKey"/>
+    <add key="BittrexApiSecret" value="ApiSecret"/>
+  </appSettings>
+</configuration>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -45,15 +45,18 @@
       <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AccountApiUnitTests.cs" />
+    <Compile Include="ApiConfigTests.cs" />
     <Compile Include="MarketApiUnitTests.cs" />
     <Compile Include="PublicApiUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Change configuration so that it can be retrieved from different sources. This way it can be retrieved from the database or config file. This also exposes it to be changed by deployers like Octopus.

Can you advise me as to the default registry location?
64 Bit is HKLM\SOFTWARE\Bittrex
32 Bit is HKLM\SOFTWARE\WOW6432Node\Bittrex